### PR TITLE
compile libraries into release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
                     output_name+='.exe'
                 fi
 
-                env GOOS=$GOOS GOARCH=$GOARCH go build -o $output_name
+                env CGO_ENABLED=0 GOOS=$GOOS GOARCH=$GOARCH go build -o $output_name
 
                 zip -v terraform-harbor-provider-$GOOS-$GOARCH $output_name
                 rm $output_name


### PR DESCRIPTION
**why**
I am seeing the following error messages. After researching a few things, it seems that alpine linux based images, like hashicorp/terraform, do not properly fork and exec binaries that do not have their libraries compiled into the binary.
```bash
Error: Failed to instantiate provider "harbor" to obtain schema: fork/exec /home/jenkins/agent/workspace/test/.terraform/plugins/linux_amd64/terraform-provider-harbor_v0.0.7: no such file or directory
```

**info**
https://github.com/terraform-providers/terraform-provider-helm/issues/59
https://github.com/terraform-providers/terraform-provider-helm/pull/111

https://serverfault.com/a/963315
https://medium.com/@laiello/cgo-with-custom-terraform-providers-65135604fa8c
https://github.com/hashicorp/terraform/blob/master/Dockerfile